### PR TITLE
第I部-第6章読破

### DIFF
--- a/src/Dollar.php
+++ b/src/Dollar.php
@@ -12,10 +12,8 @@ namespace App;
  * Class Dollar
  * @package App
  */
-class Dollar
+class Dollar extends Money
 {
-    private $amount;
-
     /**
      * Dollar constructor.
      * @param int $amount
@@ -32,14 +30,5 @@ class Dollar
     public function times(int $multiplier) : Dollar
     {
         return new Dollar($this->amount * $multiplier);
-    }
-
-    /**
-     * @param Dollar $dollar
-     * @return bool
-     */
-    public function equals(Dollar $dollar) : bool
-    {
-        return $this->amount == $dollar->amount;
     }
 }

--- a/src/Franc.php
+++ b/src/Franc.php
@@ -12,10 +12,8 @@ namespace App;
  * Class Franc
  * @package App
  */
-class Franc
+class Franc extends Money
 {
-    private $amount;
-
     /**
      * Franc constructor.
      * @param int $amount
@@ -29,16 +27,8 @@ class Franc
      * @param int $multiplier
      * @return Franc
      */
-    public function times(int $multiplier)
+    public function times(int $multiplier) : Franc
     {
         return new Franc($this->amount * $multiplier);
-    }
-
-    /**
-     * @param Franc $franc
-     */
-    public function equals(Franc $franc)
-    {
-        return $this->amount == $franc->amount;
     }
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: yagishitasho
+ * Date: 2018/01/17
+ * Time: 13:19
+ */
+
+namespace App;
+
+/**
+ * Class Money
+ * @package App
+ */
+class Money
+{
+    protected $amount;
+
+    /**
+     * @param Money $money
+     * @return bool
+     */
+    public function equals(Money $money) : bool
+    {
+        return $this->amount == $money->amount;
+    }
+}

--- a/test/MoneyTest.php
+++ b/test/MoneyTest.php
@@ -22,6 +22,11 @@ class MoneyTest extends TestCase
         $this->assertTrue($product->equals(new Dollar(5)));
         $product = new Dollar(5);
         $this->assertFalse($product->equals(new Dollar(6)));
+
+        $product = new Franc(5);
+        $this->assertTrue($product->equals(new Franc(5)));
+        $product = new Franc(5);
+        $this->assertFalse($product->equals(new Franc(6)));
     }
 
     public function testFrancMultiplication()


### PR DESCRIPTION
- Dollerクラスから親クラスMoneyへ段階的にメソッドを移動した。
- 2つめのクラス (Franc) も同様にサブクラス化した。
- 2つめのequalsメソッドの差異をなくして(p.253)から、サブクラス側の実装を削除した