### PR TITLE
第I部-第8章読破

### DIFF
--- a/src/Dollar.php
+++ b/src/Dollar.php
@@ -27,7 +27,7 @@ class Dollar extends Money
      * @param int $multiplier
      * @return Dollar
      */
-    public function times(int $multiplier) : Dollar
+    public function times(int $multiplier) : Money
     {
         return new Dollar($this->amount * $multiplier);
     }

--- a/src/Franc.php
+++ b/src/Franc.php
@@ -27,7 +27,7 @@ class Franc extends Money
      * @param int $multiplier
      * @return Franc
      */
-    public function times(int $multiplier) : Franc
+    public function times(int $multiplier) : Money
     {
         return new Franc($this->amount * $multiplier);
     }

--- a/src/Money.php
+++ b/src/Money.php
@@ -43,4 +43,13 @@ abstract class Money
     {
         return new Dollar($amount);
     }
+
+    /**
+     * @param int $amount
+     * @return Money
+     */
+    public static function franc(int $amount) : Money
+    {
+        return new Franc($amount);
+    }
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -12,9 +12,18 @@ namespace App;
  * Class Money
  * @package App
  */
-class Money
+abstract class Money
 {
+    /**
+     * @var
+     */
     protected $amount;
+
+    /**
+     * @param int $multiplier
+     * @return mixed
+     */
+    abstract public function times(int $multiplier) : Money;
 
     /**
      * @param Money $money
@@ -24,5 +33,14 @@ class Money
     {
         return $this->amount == $money->amount
             && get_called_class() == get_class($money);
+    }
+
+    /**
+     * @param int $amount
+     * @return Money
+     */
+    public static function dollar(int $amount) : Money
+    {
+        return new Dollar($amount);
     }
 }

--- a/test/MoneyTest.php
+++ b/test/MoneyTest.php
@@ -12,17 +12,17 @@ class MoneyTest extends TestCase
     public function testMultiplication()
     {
         $five = Money::dollar(5);
-        $this->assertEquals(new Dollar(10), $five->times(2));
-        $this->assertEquals(new Dollar(15), $five->times(3));
+        $this->assertEquals(Money::dollar(10), $five->times(2));
+        $this->assertEquals(Money::dollar(15), $five->times(3));
     }
 
     public function testEquality()
     {
-        $this->assertTrue((new Dollar(5))->equals(new Dollar(5)));
-        $this->assertFalse((new Dollar(5))->equals(new Dollar(6)));
+        $this->assertTrue(Money::dollar(5)->equals(Money::dollar(5)));
+        $this->assertFalse((Money::dollar(5))->equals(Money::dollar(6)));
         $this->assertTrue((new Franc(5))->equals(new Franc(5)));
         $this->assertFalse((new Franc(5))->equals(new Franc(6)));
-        $this->assertFalse((new Franc(5))->equals(new Dollar(5)));
+        $this->assertFalse((new Franc(5))->equals(Money::dollar(5)));
     }
 
     public function testFrancMultiplication()

--- a/test/MoneyTest.php
+++ b/test/MoneyTest.php
@@ -11,7 +11,7 @@ class MoneyTest extends TestCase
      */
     public function testMultiplication()
     {
-        $five = new Dollar(5);
+        $five = Money::dollar(5);
         $this->assertEquals(new Dollar(10), $five->times(2));
         $this->assertEquals(new Dollar(15), $five->times(3));
     }

--- a/test/MoneyTest.php
+++ b/test/MoneyTest.php
@@ -20,15 +20,15 @@ class MoneyTest extends TestCase
     {
         $this->assertTrue(Money::dollar(5)->equals(Money::dollar(5)));
         $this->assertFalse((Money::dollar(5))->equals(Money::dollar(6)));
-        $this->assertTrue((new Franc(5))->equals(new Franc(5)));
-        $this->assertFalse((new Franc(5))->equals(new Franc(6)));
-        $this->assertFalse((new Franc(5))->equals(Money::dollar(5)));
+        $this->assertTrue((Money::franc(5))->equals(Money::franc(5)));
+        $this->assertFalse((Money::franc(5))->equals(Money::franc(6)));
+        $this->assertFalse((Money::franc(5))->equals(Money::dollar(5)));
     }
 
     public function testFrancMultiplication()
     {
-        $five = new Franc(5);
-        $this->assertEquals(new Franc(10), $five->times(2));
-        $this->assertEquals(new Franc(15), $five->times(3));
+        $five = Money::franc(5);
+        $this->assertEquals(Money::franc(10), $five->times(2));
+        $this->assertEquals(Money::franc(15), $five->times(3));
     }
 }


### PR DESCRIPTION
- 重複を除去できる状態に一歩近づくために、DollarとFrancにある2つのtimesメソッドのシグニチャを合わせた。
- せめてメソッド宣言だけは親クラスに移動した。
- Factory Methodパターン(p.246)を導入して、テストコードから2つのサブクラスの存在を隠した。
- サブクラスを隠した結果、いくつかのテストが冗長なものになったことに気づいたが、いまはそのままにしておいた。