### PR TITLE
第I部-第10章読破

### DIFF
--- a/src/Dollar.php
+++ b/src/Dollar.php
@@ -30,6 +30,6 @@ class Dollar extends Money
      */
     public function times(int $multiplier) : Money
     {
-        return new Dollar($this->amount * $multiplier, $this->currency);
+        return new Money($this->amount * $multiplier, $this->currency);
     }
 }

--- a/src/Dollar.php
+++ b/src/Dollar.php
@@ -23,13 +23,4 @@ class Dollar extends Money
     {
         parent::__construct($amount, $currency);
     }
-
-    /**
-     * @param int $multiplier
-     * @return Money
-     */
-    public function times(int $multiplier) : Money
-    {
-        return new Money($this->amount * $multiplier, $this->currency);
-    }
 }

--- a/src/Dollar.php
+++ b/src/Dollar.php
@@ -30,6 +30,6 @@ class Dollar extends Money
      */
     public function times(int $multiplier) : Money
     {
-        return Money::dollar($this->amount * $multiplier);
+        return new Dollar($this->amount * $multiplier, $this->currency);
     }
 }

--- a/src/Franc.php
+++ b/src/Franc.php
@@ -30,6 +30,6 @@ class Franc extends Money
      */
     public function times(int $multiplier) : Money
     {
-        return new Franc($this->amount * $multiplier, $this->currency);
+        return new Money($this->amount * $multiplier, $this->currency);
     }
 }

--- a/src/Franc.php
+++ b/src/Franc.php
@@ -30,6 +30,6 @@ class Franc extends Money
      */
     public function times(int $multiplier) : Money
     {
-        return Money::franc($this->amount * $multiplier);
+        return new Franc($this->amount * $multiplier, $this->currency);
     }
 }

--- a/src/Franc.php
+++ b/src/Franc.php
@@ -24,12 +24,4 @@ class Franc extends Money
         parent::__construct($amount, $currency);
     }
 
-    /**
-     * @param int $multiplier
-     * @return Money
-     */
-    public function times(int $multiplier) : Money
-    {
-        return new Money($this->amount * $multiplier, $this->currency);
-    }
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -54,7 +54,7 @@ class Money
      */
     public function equals(Money $money) : bool
     {
-        return $this->amount == $money->amount && $this->currency == $money->currency;
+        return $this->amount === $money->amount && $this->currency() === $money->currency();
     }
 
     public function toString() : string

--- a/src/Money.php
+++ b/src/Money.php
@@ -37,7 +37,7 @@ class Money
      */
     public function times(int $multiplier)
     {
-        return null;
+        return new Money($this->amount * $multiplier, $this->currency);
     }
 
     /**

--- a/src/Money.php
+++ b/src/Money.php
@@ -55,6 +55,11 @@ abstract class Money
             && get_called_class() == get_class($money);
     }
 
+    public function toString() : string
+    {
+        return $this->amount . " " . $this->currency;
+    }
+
     /**
      * @param int $amount
      * @return Money

--- a/src/Money.php
+++ b/src/Money.php
@@ -54,8 +54,7 @@ class Money
      */
     public function equals(Money $money) : bool
     {
-        return $this->amount == $money->amount
-            && get_called_class() == get_class($money);
+        return $this->amount == $money->amount && $this->currency == $money->currency;
     }
 
     public function toString() : string

--- a/src/Money.php
+++ b/src/Money.php
@@ -12,7 +12,7 @@ namespace App;
  * Class Money
  * @package App
  */
-abstract class Money
+class Money
 {
     /**
      * @var
@@ -33,9 +33,12 @@ abstract class Money
 
     /**
      * @param int $multiplier
-     * @return mixed
+     * @return null
      */
-    abstract public function times(int $multiplier) : Money;
+    public function times(int $multiplier)
+    {
+        return null;
+    }
 
     /**
      * @return string

--- a/test/MoneyTest.php
+++ b/test/MoneyTest.php
@@ -43,7 +43,7 @@ class MoneyTest extends TestCase
      */
     public function testCurrency()
     {
-        self::assertEquals("USD", Money::dollar(1)->currency());
-        self::assertEquals("CHF", Money::franc(1)->currency());
+        $this->assertEquals("USD", Money::dollar(1)->currency());
+        $this->assertEquals("CHF", Money::franc(1)->currency());
     }
 }

--- a/test/MoneyTest.php
+++ b/test/MoneyTest.php
@@ -46,4 +46,12 @@ class MoneyTest extends TestCase
         $this->assertEquals("USD", Money::dollar(1)->currency());
         $this->assertEquals("CHF", Money::franc(1)->currency());
     }
+
+    /**
+     * @test
+     */
+    public function testDifferentClassEqulity()
+    {
+        $this->assertTrue((new Money(10, "CHF"))->equals(new Franc(10, "CHF")));
+    }
 }


### PR DESCRIPTION
- サブクラスたちのtimesメソッド実装の差異をなくす(p.253)ために、まずはメソッド呼び出しをインライン化し、次にベタ書の値を変数に置き換えた。
- デバッグ用とのみに使うtoStringメソッドを、テストを書かずに実装した。
- Francの代わりにMoneyを返す変更を試み、動くか動かないかはテストに聞いてみた。
- 実験的な変更を巻き戻し、もう1つテストを書いた。再度テストを通るように実装することで、今度は実験を成功に導いた。